### PR TITLE
Suppress FFmpeg Logs

### DIFF
--- a/software/source/server/services/stt/local-whisper/stt.py
+++ b/software/source/server/services/stt/local-whisper/stt.py
@@ -156,7 +156,7 @@ def stt_wav(service_directory, wav_file_path: str):
         temp_dir, f"output_stt_{datetime.now().strftime('%Y%m%d%H%M%S%f')}.wav"
     )
     ffmpeg.input(wav_file_path).output(
-        output_path, acodec="pcm_s16le", ac=1, ar="16k"
+        output_path, acodec="pcm_s16le", ac=1, ar="16k", loglevel="panic"
     ).run()
     try:
         transcript = get_transcription_file(service_directory, output_path)


### PR DESCRIPTION
Adding `loglevel` "panic" to suppress FFmpeg logs when running STT locally.