### PR TITLE
Add Subprocess Check

### DIFF
--- a/software/source/server/services/stt/local-whisper/stt.py
+++ b/software/source/server/services/stt/local-whisper/stt.py
@@ -125,7 +125,7 @@ def export_audio_to_wav_ffmpeg(audio: bytearray, mime_type: str) -> str:
 
 def run_command(command):
     result = subprocess.run(
-        command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+        command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=True
     )
     return result.stdout, result.stderr
 

--- a/software/source/server/services/stt/openai/stt.py
+++ b/software/source/server/services/stt/openai/stt.py
@@ -70,7 +70,7 @@ def export_audio_to_wav_ffmpeg(audio: bytearray, mime_type: str) -> str:
 
 def run_command(command):
     result = subprocess.run(
-        command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+        command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=True
     )
     return result.stdout, result.stderr
 

--- a/software/source/server/utils/bytes_to_wav.py
+++ b/software/source/server/utils/bytes_to_wav.py
@@ -57,7 +57,7 @@ def export_audio_to_wav_ffmpeg(audio: bytearray, mime_type: str) -> str:
 
 def run_command(command):
     result = subprocess.run(
-        command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+        command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=True
     )
     return result.stdout, result.stderr
 


### PR DESCRIPTION
Adding `check=True` on subprocess run calls to expose command errors that would otherwise fail silently.